### PR TITLE
Issue #3: Added missing hook_config_info.

### DIFF
--- a/socialfield.module
+++ b/socialfield.module
@@ -5,6 +5,18 @@
  */
 
 /**
+ * Implements hook_config_info().
+ */
+function socialfield_config_info() {
+  $prefixes['socialfield.settings'] = array(
+    'label' => t('Socialfield settings'),
+    'group' => t('Configuration'),
+  );
+
+  return $prefixes;
+}
+
+/**
  * Implements hook_menu().
  */
 function socialfield_menu() {


### PR DESCRIPTION
Fixes https://github.com/backdrop-contrib/socialfield/issues/3
